### PR TITLE
3.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hotkey-hub",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "repository": "git@github.com:akoidan/hotkey-hub.git",
   "author": "akoidan <deathangel908@gmail.com>",
   "license": "MIT",

--- a/src/client/client-model.ts
+++ b/src/client/client-model.ts
@@ -1,5 +1,4 @@
-const CERT_DIR = 'CERT_DIR';
-const TIMEOUT = 'TIMEOUT';
+const CERT_DIR = 'CERT_DIR';;
 
 interface CustomError extends Error {
   statusCode?: number;
@@ -19,4 +18,4 @@ interface ApiOptions {
 const ABORTED_BY_USER = 'Request is aborted by user';
 
 export type {CustomError, RequestOptions, ApiOptions};
-export {CERT_DIR, TIMEOUT, ABORTED_BY_USER};
+export {CERT_DIR, ABORTED_BY_USER};

--- a/src/client/client-module.ts
+++ b/src/client/client-module.ts
@@ -9,7 +9,6 @@ import {MonitorService} from '@/client/services/monitor.service';
 import {MouseService} from '@/client/services/mouse.service';
 import {ProcessService} from '@/client/services/process.service';
 import {WindowService} from '@/client/services/window.service';
-import {TIMEOUT} from '@/client/client-model';
 import {Agent} from 'https';
 import {AsyncStorageModule} from '@/asyncstore/async-storage.module';
 import {AppService} from '@/client/services/app.service';
@@ -28,10 +27,6 @@ import {AppService} from '@/client/services/app.service';
     MonitorService,
     MouseService,
     ProcessService,
-    {
-      provide: TIMEOUT,
-      useValue: 6000,
-    },
     {
       provide: Agent,
       inject: [CertService],

--- a/src/client/http-client.ts
+++ b/src/client/http-client.ts
@@ -6,7 +6,7 @@ import clc from 'cli-color';
 import {SemaphorService} from '@/semaphor/semaphor-service';
 import {ASYNC_PROVIDER} from '@/asyncstore/async-storage-const';
 import {AsyncLocalStorage} from 'async_hooks';
-import {CustomError, RequestOptions, TIMEOUT} from '@/client/client-model';
+import {CustomError, RequestOptions} from '@/client/client-model';
 
 
 @Injectable()
@@ -16,8 +16,6 @@ export class FetchClient {
     private readonly config: ConfigService,
     private readonly agent: Agent,
     private readonly semaphorService: SemaphorService,
-    @Inject(TIMEOUT)
-    private readonly timeout: number,
     @Inject(ASYNC_PROVIDER)
     private readonly asyncLocalStorage: AsyncLocalStorage<Map<string, any>>,
   ) {
@@ -131,7 +129,7 @@ export class FetchClient {
         httpController.abort();
         reject!(Error(controller.signal.reason as string));
       };
-      const realTimeout = options.timeout ?? this.timeout;
+      const realTimeout = options.timeout ?? this.config.getDelays().httpRequest;
       const [result, statusCode] = await Promise.race([
         this.executeRequest(method, client, url, payloadstr, httpController),
         new Promise<never>((_, innerReject) => {

--- a/src/config/config-service.ts
+++ b/src/config/config-service.ts
@@ -220,12 +220,16 @@ export class ConfigService implements ConfigProvider {
     return this.configData!.clientPort!;
   }
 
-  public setVariable(name: string, value: unknown): void {
+  public setVariable(name: string, value: unknown, printLog: boolean = false): void {
     if (typeof name !== 'string') {
       throw new Error(`Unable to assign variable ${JSON.stringify(name)} to value ${JSON.stringify(value)}, cause key is not a string`);
     }
     this.variables[name] = value;
-    this.logger.debug(`Settings variable ${name}=${JSON.stringify(value)}`);
+    if (printLog) {
+      this.logger.log(`${clc.bold.green(name)}=${clc.yellow(JSON.stringify(value))}`);
+    } else {
+      this.logger.debug(`Settings variable ${name}=${JSON.stringify(value)}`);
+    }
     if (this.saveTimeout < 0) {
       return; // do not perform save on tests
     }

--- a/src/config/types/delays.ts
+++ b/src/config/types/delays.ts
@@ -11,6 +11,11 @@ const globalDelaySchema = z.object({
     .describe('Timeout (in milliseconds) for HTTP request. If timeout is exceeded, request will fail and command will be terminated.')
     .optional(),
 
+  httpRequestInit: z.number()
+    .default(3000)
+    .describe('Timeout (in milliseconds) for the first request to check all clients')
+    .optional(),
+
   afterCommand: z.number()
     .default(0)
     .describe('Base delay (in milliseconds) after each command. Can be randomized using standardDeviation.')

--- a/src/config/types/delays.ts
+++ b/src/config/types/delays.ts
@@ -22,7 +22,7 @@ const globalDelaySchema = z.object({
     .optional(),
 
   standardDeviation: z.number()
-    .positive()
+    .nonnegative()
     .max(1)
     .default(0)
     .describe('Controls randomness of global before/after delays.'
@@ -31,7 +31,7 @@ const globalDelaySchema = z.object({
     .optional(),
 
   commandDeviation: z.number()
-    .positive()
+    .nonnegative()
     .max(1)
     .default(0)
     .describe('Controls randomness of delays before/after on each command. ' +
@@ -41,7 +41,7 @@ const globalDelaySchema = z.object({
     .optional(),
 
   randomHugeDelayDeviation: z.number()
-    .positive()
+    .nonnegative()
     .max(1)
     .default(0)
     .describe('Deviation factor for huge delay. Applied only when randomHugeDelayChance is triggered. '
@@ -49,14 +49,14 @@ const globalDelaySchema = z.object({
     .optional(),
 
   randomHugeDelay: z.number()
-    .positive()
+    .nonnegative()
     .default(0)
     .describe('Extra delay (in milliseconds) added on top of standard delays. '
       + 'Only applies when randomHugeDelayChance is triggered.')
     .optional(),
 
   randomHugeDelayChance: z.number()
-    .positive()
+    .nonnegative()
     .max(1)
     .default(0)
     .describe('Probability (0 to 1) of applying a random huge delay after the standard delay.')
@@ -64,6 +64,7 @@ const globalDelaySchema = z.object({
 })
   .strict()
   .optional()
+  .prefault({})
   .describe('Global delays config between commands. If ommited commands will run instantly after each other');
 
 type DelayData = z.infer<typeof globalDelaySchema>

--- a/src/config/types/delays.ts
+++ b/src/config/types/delays.ts
@@ -6,6 +6,11 @@ const globalDelaySchema = z.object({
     .describe('Base delay (in milliseconds) before each command. Can be randomized using standardDeviation.')
     .optional(),
 
+  httpRequest: z.number()
+    .default(6000)
+    .describe('Timeout (in milliseconds) for HTTP request. If timeout is exceeded, request will fail and command will be terminated.')
+    .optional(),
+
   afterCommand: z.number()
     .default(0)
     .describe('Base delay (in milliseconds) after each command. Can be randomized using standardDeviation.')

--- a/src/config/types/variables.ts
+++ b/src/config/types/variables.ts
@@ -2,10 +2,10 @@ import {z, type ZodObject, type ZodTypeAny} from 'zod';
 import {type DelayData, globalDelaySchema} from '@/config/types/delays';
 
 
-const variablesSchema = z.object({delay: globalDelaySchema.optional()})
+const variablesSchema = z.object({delays: globalDelaySchema.optional()})
   .catchall(z.any())
   .optional()
-  .default({})
+  .prefault({})
   .describe('Variable definitions for configuration.' +
     ' Values can be any type (numeric strings auto-convert to integers). Use {$ref: "varName"} to reference.');
 

--- a/src/local/implementation/expression-local-handler.ts
+++ b/src/local/implementation/expression-local-handler.ts
@@ -38,11 +38,10 @@ export class ExpressionLocalHandler extends BaseLocalHandler {
         nextVal = nextVal[varPath[i]]
       }
       nextVal[varPath[varPath.length - 1]] = result;
-      this.configService.setVariable(mainVariable, mainValue);
+      this.configService.setVariable(mainVariable, mainValue, true);
     } else {
-      this.configService.setVariable(varToAssign, result);
+      this.configService.setVariable(varToAssign, result, true);
     }
-    this.logger.debug(`${clc.bold.green(varToAssign)}=${clc.yellow(JSON.stringify(result))}`);
   }
 
   /* eslint-enable */

--- a/src/local/implementation/expression-local-handler.ts
+++ b/src/local/implementation/expression-local-handler.ts
@@ -1,6 +1,5 @@
 import {ConfigService} from '@/config/config-service';
 import {Injectable, Logger} from '@nestjs/common';
-import clc from 'cli-color';
 import {BaseLocalHandler} from '@/local/base-local-handler';
 import {ExpressionLocalCommand} from '@/config/types/local/local-commands';
 import {UnknownCommand} from '@/config/types/commands';

--- a/src/local/implementation/print-local-handler.ts
+++ b/src/local/implementation/print-local-handler.ts
@@ -21,7 +21,7 @@ export class PrintLocalHandler extends BaseLocalHandler {
   // eslint-disable-next-line @typescript-eslint/require-await
   async execute(comb: PrintLocalCommand): Promise<void> {
     const result: unknown = this.evaluateService.evaluateExpression(comb.print);
-    this.logger.log(`${clc.yellow(comb.print)}=${clc.bold.green(result)}`);
+    this.logger.log(result);
   }
 }
 

--- a/src/local/implementation/print-local-handler.ts
+++ b/src/local/implementation/print-local-handler.ts
@@ -3,7 +3,6 @@ import {BaseLocalHandler} from '@/local/base-local-handler';
 import {PrintLocalCommand} from '@/config/types/local/local-commands';
 import {UnknownCommand} from '@/config/types/commands';
 import {EvaluateService} from '@/local/evaluate-serivce';
-import clc from 'cli-color';
 
 @Injectable()
 export class PrintLocalHandler extends BaseLocalHandler {

--- a/src/local/implementation/prompt-local-handler.ts
+++ b/src/local/implementation/prompt-local-handler.ts
@@ -59,7 +59,7 @@ export class PromptLocalHandler extends BaseLocalHandler {
     controller.signal.removeEventListener('abort', abortHandler);
     // eslint-disable-next-line guard-for-in
     for (const k in res) {
-      this.configService.setVariable(k, res[k]);
+      this.configService.setVariable(k, res[k], true);
     }
   }
 }

--- a/src/local/implementation/transaction-local-handler.ts
+++ b/src/local/implementation/transaction-local-handler.ts
@@ -105,7 +105,7 @@ export class TransactionLocalHandler extends BaseLocalHandler {
         `transaction ${tId}`
       );
     }
-        for (let i = 0; i < preparedInput.commands.length; i++) {
+    for (let i = 0; i < preparedInput.commands.length; i++) {
       const delayA = ((preparedInput as Delay).delayAfter as number | undefined) ?? combDelayAfter;
       const delayB = ((preparedInput as Delay).delayBefore as number | undefined) ?? combDelayBefore;
       const transactionPromise = this.semaphoreService.spawnPromiseChild(

--- a/src/local/keybinding-service.ts
+++ b/src/local/keybinding-service.ts
@@ -39,7 +39,7 @@ export class KeybindingService {
   }
 
   private async verifyClientVersion(destination: string): Promise<void> {
-    const res = await this.clientService.app.ping(destination, {timeout: 3000});
+    const res = await this.clientService.app.ping(destination, {timeout: this.configService.getDelays().httpRequestInit});
     const [major] = this.version.split('.');
     let clientVersion = '1.x.x';
     if (res.version) {

--- a/src/local/shortcut-processing.service.ts
+++ b/src/local/shortcut-processing.service.ts
@@ -40,6 +40,11 @@ export class ShortcutProcessingService {
         }
       } catch (e: any) {
         finalLedColor = KeyState.ERROR!;
+        // if thread handler has multiple operations in progress
+        // (e.g. thread with 2 infinitive loops for easier reproduce)
+        // when first loop throws, we6000m have to aborts 2nd loop as well
+        // also if first loop throw it should NOT have subsribers on abort controller
+        this.semaphoreService.getAbortController().abort(e);
         throw e;
       } finally {
         const index = this.iterationsInProgress[groupWith].findIndex(proc => proc.id === id);

--- a/tests/config-service.spec.ts
+++ b/tests/config-service.spec.ts
@@ -110,3 +110,22 @@ describe('Config service — JSON Schema variable validation', () => {
   });
 
 });
+
+describe('Config service — nested delay defaults', () => {
+  it('Should apply per-field delay defaults when config and variables omit "delays" entirely', async () => {
+    const testModule = await getTestModule('no-variables-config-fixture.jsonc');
+    const service = testModule.get<ConfigService>(ConfigService);
+    await service.parseConfig();
+    expect(service.getDelays()).toEqual({
+      beforeCommand: 0,
+      httpRequest: 6000,
+      httpRequestInit: 3000,
+      afterCommand: 0,
+      standardDeviation: 0,
+      commandDeviation: 0,
+      randomHugeDelayDeviation: 0,
+      randomHugeDelay: 0,
+      randomHugeDelayChance: 0,
+    });
+  });
+});

--- a/tests/fixtures/no-variables-config-fixture.jsonc
+++ b/tests/fixtures/no-variables-config-fixture.jsonc
@@ -1,0 +1,4 @@
+{
+  "ips": {},
+  "combinations": []
+}


### PR DESCRIPTION
- default values from inner config + fixed wrong default config name (delay -> delays)
- fixed alt+i bug when exception in one of the threads didnt stop the whole runnable combination and caused pausable behaviour to keep running forever
- moved some fixed values from contants to config
- better visual logging for set variable